### PR TITLE
Possible issue fix with building game

### DIFF
--- a/PantoScripts/DualPantoSync.cs
+++ b/PantoScripts/DualPantoSync.cs
@@ -304,7 +304,9 @@ public class DualPantoSync : MonoBehaviour
     {
         if (unityBounds == null) {
             Debug.LogError("[DualPanto] Unity Bounds are null, did you forget to create a Play Area?");
+#if UNITY_EDITOR
             UnityEditor.EditorApplication.isPlaying = false;
+#endif
         }
         float newX = (point.x - unityBounds[0].x) * pantoBounds[1].x / unityBounds[1].x + pantoBounds[0].x;
         float newY = (point.y - unityBounds[0].y) * pantoBounds[1].y / unityBounds[1].y + pantoBounds[0].y;
@@ -314,7 +316,9 @@ public class DualPantoSync : MonoBehaviour
     {
         if (unityBounds == null) {
             Debug.LogError("[DualPanto] Unity Bounds are null, did you forget to create a Play Area?");
+#if UNITY_EDITOR
             UnityEditor.EditorApplication.isPlaying = false;
+#endif
         }
         float newX = (point.x - pantoBounds[0].x) * unityBounds[1].x / pantoBounds[1].x + unityBounds[0].x;
         float newY = (point.y - pantoBounds[0].y) * unityBounds[1].y / pantoBounds[1].y + unityBounds[0].y;


### PR DESCRIPTION
When trying to build a game containing the DualPantoSync.cs script the following error appears: 
> Assets/unity-dualpanto-framework/PantoScripts/DualPantoSync.cs(308,13): error CS0234: The type or namespace name 'EditorApplication' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)

Fix (see suggestions [here](https://answers.unity.com/questions/316805/unityeditor-namespace-not-found.html?_ga=2.115366402.527097784.1591362764-1586944223.1591194712)) could be adding a [Platform dependent compilation](https://docs.unity3d.com/Manual/PlatformDependentCompilation.html).

Tested on _macOS 10.15.4 with Unity 2019.2.12f1_.