### PR TITLE
[Suggestion] Adding context menu to choose specific panto game objects

### DIFF
--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 18d623cd723f6b543974739798cc3e90
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PantoObjectMenu.cs
+++ b/Assets/Scripts/PantoObjectMenu.cs
@@ -1,23 +1,19 @@
 ﻿using UnityEditor;
 using UnityEngine;
+using DualPantoFramework;
+
 public class PantoObjectMenu : MonoBehaviour
 {
-    // Add a menu item named "Do Something" to MyMenu in the menu bar.
-    [MenuItem("DualPanto/Do Something")]
-    static void DoSomething()
-    {
-        Debug.Log("Doing Something...");
-    }
-
     // Add a menu item to create custom GameObjects.
     // Priority 1 ensures it is grouped with the other menu items of the same kind
     // and propagated to the hierarchy dropdown and hierarchy context menus.
-    [MenuItem("GameObject/Panto/Player", false, 10)]
+    [MenuItem("GameObject/Panto/MeHandle", false, 10)]
     static void CreatePantoPlayer(MenuCommand menuCommand)
     {
         // Create a custom game object
         GameObject go = GameObject.CreatePrimitive(PrimitiveType.Cube);
-        go.AddComponent<Player>();
+        go.name = "MeHandle";
+        go.AddComponent<MeHandle>();
         // Ensure it gets reparented if this was a context click (otherwise does nothing)
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
         // Register the creation in the undo system
@@ -30,6 +26,7 @@ public class PantoObjectMenu : MonoBehaviour
     {
         // Create a custom game object
         GameObject wall = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        wall.name = "Wall";
         wall.AddComponent<PantoBoxCollider>();
         // Ensure it gets reparented if this was a context click (otherwise does nothing)
         GameObjectUtility.SetParentAndAlign(wall, menuCommand.context as GameObject);

--- a/Assets/Scripts/PantoObjectMenu.cs.meta
+++ b/Assets/Scripts/PantoObjectMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a49e070927adb524f82b1cbd0486b6a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hierarchy context menu includes a Panto option which includes different MenuItems like Player, Panto, Wall, etc.

Also includes Panto MenuBar