### PR TITLE
Added a bunch of preprocessor directives to enable building

### DIFF
--- a/Assets/PantoScripts/DualPantoSync.cs
+++ b/Assets/PantoScripts/DualPantoSync.cs
@@ -460,11 +460,7 @@ namespace DualPantoFramework
 
         void OnStopApp()
         {
-#if UNITY_EDITOR
             EditorApplication.isPlaying = false;
-#else
-         Application.Quit();
-#endif
         }
 
     }


### PR DESCRIPTION
Previously got a bunch of error messages because Unity tried to build the _DualPantoSync.cs_ file which contained `EditorWindow` that can't be build for the player.