### PR TITLE
Hotfix sync issue and obstacle creation

### DIFF
--- a/Assets/ExampleScripts/ItHandle.cs
+++ b/Assets/ExampleScripts/ItHandle.cs
@@ -17,9 +17,7 @@ public class ItHandle : MonoBehaviour
 
     void FixedUpdate()
     {
-        //if (!DualPantoToolkit.DualPantoSync.IsPantoReady) return;
         transform.position = lowerHandle.GetPosition();
-        //transform.position = lowerHandle.HandlePosition(transform.position);
         transform.eulerAngles = new Vector3(0, lowerHandle.GetRotation(), 0);
     }
 

--- a/Assets/ExampleScripts/ItHandle.cs
+++ b/Assets/ExampleScripts/ItHandle.cs
@@ -17,7 +17,7 @@ public class ItHandle : MonoBehaviour
 
     void FixedUpdate()
     {
-        if (!DualPantoToolkit.DualPantoSync.IsPantoReady) return;
+        //if (!DualPantoToolkit.DualPantoSync.IsPantoReady) return;
         transform.position = lowerHandle.GetPosition();
         //transform.position = lowerHandle.HandlePosition(transform.position);
         transform.eulerAngles = new Vector3(0, lowerHandle.GetRotation(), 0);

--- a/Assets/ExampleScripts/ItHandle.cs
+++ b/Assets/ExampleScripts/ItHandle.cs
@@ -5,14 +5,22 @@ public class ItHandle : MonoBehaviour
 {
     PantoHandle lowerHandle;
     bool free = true;
+
     void Start()
     {
         lowerHandle = GameObject.Find("Panto").GetComponent<LowerHandle>();
+        if (lowerHandle == null)
+        {
+            Debug.LogError("[DualPanto] LowerHandle not found on Panto GameObject!");
+        }
     }
 
     void FixedUpdate()
     {
-        transform.position = lowerHandle.HandlePosition(transform.position);
+        if (!DualPantoToolkit.DualPantoSync.IsPantoReady) return;
+        transform.position = lowerHandle.GetPosition();
+        //transform.position = lowerHandle.HandlePosition(transform.position);
+        transform.eulerAngles = new Vector3(0, lowerHandle.GetRotation(), 0);
     }
 
     void Update()

--- a/Assets/ExampleScripts/MeHandle.cs
+++ b/Assets/ExampleScripts/MeHandle.cs
@@ -17,7 +17,7 @@ public class MeHandle : MonoBehaviour
 
     void FixedUpdate()
     {
-        if (!DualPantoToolkit.DualPantoSync.IsPantoReady) return;
+        //if (!DualPantoToolkit.DualPantoSync.IsPantoReady) return;
         transform.position = upperHandle.GetPosition();
         //transform.position = upperHandle.HandlePosition(transform.position);
         transform.eulerAngles = new Vector3(0, upperHandle.GetRotation(), 0);

--- a/Assets/ExampleScripts/MeHandle.cs
+++ b/Assets/ExampleScripts/MeHandle.cs
@@ -3,16 +3,23 @@ using DualPantoToolkit;
 
 public class MeHandle : MonoBehaviour
 {
-    bool free = true;
     PantoHandle upperHandle;
+    bool free = true;
+    
     void Start()
     {
         upperHandle = GameObject.Find("Panto").GetComponent<UpperHandle>();
+        if (upperHandle == null)
+        {
+            Debug.LogError("[DualPanto] UpperHandle not found on Panto GameObject!");
+        }
     }
 
     void FixedUpdate()
     {
-        transform.position = (upperHandle.HandlePosition(transform.position));
+        if (!DualPantoToolkit.DualPantoSync.IsPantoReady) return;
+        transform.position = upperHandle.GetPosition();
+        //transform.position = upperHandle.HandlePosition(transform.position);
         transform.eulerAngles = new Vector3(0, upperHandle.GetRotation(), 0);
     }
 

--- a/Assets/ExampleScripts/MeHandle.cs
+++ b/Assets/ExampleScripts/MeHandle.cs
@@ -17,9 +17,7 @@ public class MeHandle : MonoBehaviour
 
     void FixedUpdate()
     {
-        //if (!DualPantoToolkit.DualPantoSync.IsPantoReady) return;
         transform.position = upperHandle.GetPosition();
-        //transform.position = upperHandle.HandlePosition(transform.position);
         transform.eulerAngles = new Vector3(0, upperHandle.GetRotation(), 0);
     }
 

--- a/Assets/ExampleScripts/ObstacleManager.cs
+++ b/Assets/ExampleScripts/ObstacleManager.cs
@@ -5,7 +5,7 @@ public class ObstacleManager : MonoBehaviour
     PantoCollider[] pantoColliders;
     void Start()
     {
-        Invoke("createObstacles", 1.0f);
+        Invoke("createObstacles", 2.0f);
     }
 
     private void createObstacles()

--- a/Assets/ExampleScripts/ObstacleManager.cs
+++ b/Assets/ExampleScripts/ObstacleManager.cs
@@ -5,7 +5,7 @@ public class ObstacleManager : MonoBehaviour
     PantoCollider[] pantoColliders;
     void Start()
     {
-        Invoke("createObstacles", 2.0f);
+        Invoke("createObstacles", 1.0f);
     }
 
     private void createObstacles()

--- a/Assets/Overcooked/RegisterCollider.cs
+++ b/Assets/Overcooked/RegisterCollider.cs
@@ -4,6 +4,7 @@ using DualPantoToolkit;
 
 public class RegisterCollider : MonoBehaviour
 {
+    /*
     async void Start()
     {
         await Task.Delay(2000);
@@ -14,4 +15,5 @@ public class RegisterCollider : MonoBehaviour
             collider.Enable();
         }
     }
+    */
 }

--- a/Assets/PantoScripts/ActivateObstaclesSphere.cs
+++ b/Assets/PantoScripts/ActivateObstaclesSphere.cs
@@ -7,21 +7,23 @@ namespace DualPantoToolkit
     {
         void OnTriggerEnter(Collider collider)
         {
+            /*
             PantoCollider pc = collider.GetComponent<PantoCollider>();
             if (pc != null && pc.enabled)
             {
                 if (pc.GetContainingSpheres() == 0)
                 {
                     pc.CreateObstacle();
-                    //if (pc.IsEnabled()) pc.Enable();
                     pc.Enable();
                 }
                 pc.IncreaseSpheres();
             }
+            */
         }
 
         void OnTriggerExit(Collider collider)
         {
+            /*
             PantoCollider pc = collider.GetComponent<PantoCollider>();
             if (pc != null)
             {
@@ -31,6 +33,7 @@ namespace DualPantoToolkit
                     pc.Remove();
                 }
             }
+            */
         }
     }
 }

--- a/Assets/PantoScripts/ActivateObstaclesSphere.cs
+++ b/Assets/PantoScripts/ActivateObstaclesSphere.cs
@@ -7,7 +7,6 @@ namespace DualPantoToolkit
     {
         void OnTriggerEnter(Collider collider)
         {
-            /*
             PantoCollider pc = collider.GetComponent<PantoCollider>();
             if (pc != null && pc.enabled)
             {
@@ -18,12 +17,10 @@ namespace DualPantoToolkit
                 }
                 pc.IncreaseSpheres();
             }
-            */
         }
 
         void OnTriggerExit(Collider collider)
         {
-            /*
             PantoCollider pc = collider.GetComponent<PantoCollider>();
             if (pc != null)
             {
@@ -33,7 +30,6 @@ namespace DualPantoToolkit
                     pc.Remove();
                 }
             }
-            */
         }
     }
 }

--- a/Assets/PantoScripts/ColliderRegistry.cs
+++ b/Assets/PantoScripts/ColliderRegistry.cs
@@ -14,7 +14,7 @@ namespace DualPantoToolkit
             {
                 await Task.Delay(10);
                 collider.CreateObstacle();
-                if (collider.IsEnabled()) collider.Enable();
+                if (!collider.IsEnabled()) collider.Enable();
             }
         }
 

--- a/Assets/PantoScripts/DualPantoSync.cs
+++ b/Assets/PantoScripts/DualPantoSync.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace DualPantoToolkit
@@ -55,6 +56,7 @@ namespace DualPantoToolkit
         protected ulong Handle;
         private static LowerHandle lowerHandle;
         private static UpperHandle upperHandle;
+        public static bool IsPantoReady { get; private set; } = false;
 
         // bounds are defined by center and extent
         //private static Vector2[] pantoBounds = { new Vector2(0, -110), new Vector2(320, 160) }; // for version D
@@ -80,7 +82,7 @@ namespace DualPantoToolkit
 #elif UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
         private const string plugin = "libserial.so";
 #else
-    private const string plugin = "libserial";
+        private const string plugin = "libserial";
 #endif
 
         private static bool connected = false;
@@ -138,7 +140,7 @@ namespace DualPantoToolkit
 
         void Start()
         {
-            Application.targetFrameRate = 60;
+            Application.targetFrameRate = 30;
         }
 
         private static void SyncHandler(ulong handle)
@@ -206,14 +208,17 @@ namespace DualPantoToolkit
             }
         }
 
-        private void OnPantoStarted()
+        private async void OnPantoStarted()
         {
-            connected = false;
-            while (!connected)
-            {
-                Poll(Handle);
-            }
-            ColliderRegistry.RegisterObstacles();
+            // Wait until both handles are registered
+            //while (upperHandle == null || lowerHandle == null)
+            //    await Task.Yield();
+
+            Debug.Log("[DualPanto] Panto is fully ready!");
+            IsPantoReady = true;
+
+            // Now it's safe to register obstacles or send commands
+            //ColliderRegistry.RegisterObstacles();
         }
 
         private void PositionHandler(ulong handle, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8, SizeConst = 10)] double[] positions)
@@ -335,15 +340,17 @@ namespace DualPantoToolkit
                 Reset();
                 if (showRawValues) SetUpDebugValuesWindow();
                 globalSync = this;
+
                 SetLoggingHandler(StaticLogHandler);
                 SetSyncHandler(SyncHandler);
                 SetHeartbeatHandler(StaticHeartbeatHandler);
                 SetPositionHandler(StaticPositionHandler);
                 SetTransitionHandler(StaticTransitionHandler);
+
                 SetPort(portName);
                 // keep polling until we receive the first SYNC (which we ACK in the handler and set connected)
                 // only then everyone else can start sending their own stuff
-                while (!connected && Handle != 0)
+                while (!IsPantoReady)
                 {
                     Poll(Handle);
                 }
@@ -415,7 +422,11 @@ namespace DualPantoToolkit
         {
             FreeHandle(true);
             FreeHandle(false);
-            if (Handle != 0) Close(Handle);
+            if (Handle != 0)
+            {
+                Close(Handle);
+                Handle = 0;
+            }
         }
 
         void Update()
@@ -424,13 +435,15 @@ namespace DualPantoToolkit
             {
                 if (Handle != 0)
                 {
-                    if (connected)
+                    Poll(Handle);
+                    if (!initialPoll)
+                    {
+                        initialPoll = true;
+                    }
+                    if (IsPantoReady)
                     {
                         CheckQueuedPackets(20);
                     }
-                    Poll(Handle);
-                    if (!initialPoll)
-                        initialPoll = true;
                 }
             }
             else
@@ -506,6 +519,7 @@ namespace DualPantoToolkit
 
         public void UpdateHandlePosition(Vector3? pos, float? rotation, bool isUpper)
         {
+            if (!IsPantoReady && !debug) return;
             if (debug)
             {
                 GameObject debugObject = GetDebugObject(isUpper);
@@ -521,7 +535,7 @@ namespace DualPantoToolkit
             if (pos != null)
             {
                 Vector3 definitePosition = (Vector3)pos;
-                if (IsInBounds(new Vector2(definitePosition.x, definitePosition.z))) 
+                if (IsInBounds(new Vector2(definitePosition.x, definitePosition.z)))
                 {
                     Vector2 pantoPoint = UnityToPanto(new Vector2(definitePosition.x, definitePosition.z));
                     pantoX = pantoPoint.x;
@@ -575,7 +589,7 @@ namespace DualPantoToolkit
 
         private static float UnityToPantoRotation(float rotation)
         {
-            return (-rotation% 360) / (180f / Mathf.PI);
+            return (-rotation % 360) / (180f / Mathf.PI);
         }
 
         private static float PantoToUnityRotation(double pantoDegrees)
@@ -621,6 +635,7 @@ namespace DualPantoToolkit
 
         public void CreateObstacle(byte pantoIndex, ushort obstacleId, Vector2 startPoint, Vector2 endPoint)
         {
+            if (!IsPantoReady && !debug) return;
             if (!debug)
             {
                 Vector2 pantoStartPoint = UnityToPanto(startPoint);

--- a/Assets/PantoScripts/DualPantoSync.cs
+++ b/Assets/PantoScripts/DualPantoSync.cs
@@ -56,7 +56,6 @@ namespace DualPantoToolkit
         protected ulong Handle;
         private static LowerHandle lowerHandle;
         private static UpperHandle upperHandle;
-        public static bool IsPantoReady { get; private set; } = false;
 
         // bounds are defined by center and extent
         //private static Vector2[] pantoBounds = { new Vector2(0, -110), new Vector2(320, 160) }; // for version D
@@ -211,11 +210,17 @@ namespace DualPantoToolkit
         private async void OnPantoStarted()
         {
             // Wait until both handles are registered
-            //while (upperHandle == null || lowerHandle == null)
-            //    await Task.Yield();
-
+            while (upperHandle == null || lowerHandle == null)
+            {
+                await Task.Yield();
+            }
+            while (!connected && Handle != 0)
+            {
+                Poll(Handle);
+                await Task.Yield();
+            }
+            
             Debug.Log("[DualPanto] Panto is fully ready!");
-            IsPantoReady = true;
 
             // Now it's safe to register obstacles or send commands
             //ColliderRegistry.RegisterObstacles();
@@ -350,7 +355,7 @@ namespace DualPantoToolkit
                 SetPort(portName);
                 // keep polling until we receive the first SYNC (which we ACK in the handler and set connected)
                 // only then everyone else can start sending their own stuff
-                while (!IsPantoReady)
+                while (Handle != 0 && !connected)
                 {
                     Poll(Handle);
                 }
@@ -440,7 +445,7 @@ namespace DualPantoToolkit
                     {
                         initialPoll = true;
                     }
-                    if (IsPantoReady)
+                    if (connected)
                     {
                         CheckQueuedPackets(20);
                     }
@@ -519,7 +524,7 @@ namespace DualPantoToolkit
 
         public void UpdateHandlePosition(Vector3? pos, float? rotation, bool isUpper)
         {
-            if (!IsPantoReady && !debug) return;
+            if (!connected && !debug) return;
             if (debug)
             {
                 GameObject debugObject = GetDebugObject(isUpper);
@@ -635,7 +640,7 @@ namespace DualPantoToolkit
 
         public void CreateObstacle(byte pantoIndex, ushort obstacleId, Vector2 startPoint, Vector2 endPoint)
         {
-            if (!IsPantoReady && !debug) return;
+            if (!connected && !debug) return;
             if (!debug)
             {
                 Vector2 pantoStartPoint = UnityToPanto(startPoint);

--- a/Assets/PantoScripts/DualPantoSync.cs
+++ b/Assets/PantoScripts/DualPantoSync.cs
@@ -440,14 +440,14 @@ namespace DualPantoToolkit
             {
                 if (Handle != 0)
                 {
+                    if (connected)
+                    {
+                        CheckQueuedPackets(20);
+                    }
                     Poll(Handle);
                     if (!initialPoll)
                     {
                         initialPoll = true;
-                    }
-                    if (connected)
-                    {
-                        CheckQueuedPackets(20);
                     }
                 }
             }

--- a/Assets/PantoScripts/DualPantoSync.cs
+++ b/Assets/PantoScripts/DualPantoSync.cs
@@ -139,7 +139,7 @@ namespace DualPantoToolkit
 
         void Start()
         {
-            Application.targetFrameRate = 30;
+            Application.targetFrameRate = 60;
         }
 
         private static void SyncHandler(ulong handle)

--- a/Assets/PantoScripts/PantoHandle.cs
+++ b/Assets/PantoScripts/PantoHandle.cs
@@ -233,34 +233,50 @@ namespace DualPantoToolkit
 
         public void SetPositions(Vector3 newPosition, float? newRotation, Vector3? newGodObjectPosition)
         {
-            GameObject debugGodObject = pantoSync.GetDebugGodObject(isUpper);
-            if (pantoSync.debug && newRotation != null)
-            {
-                Debug.Log("setting rotation");
-                GameObject debugObject = pantoSync.GetDebugObject(isUpper);
-                debugObject.transform.eulerAngles = new Vector3(debugObject.transform.eulerAngles.x, (float)newRotation, debugObject.transform.eulerAngles.z);
-            }
-            if (pantoSync.debug)// && userControlledPosition)
-            {
-                GameObject debugObject = pantoSync.GetDebugObject(isUpper);
-                debugObject.transform.position = newPosition;
-                debugGodObject.transform.position = newPosition;
-                debugGodObject.transform.eulerAngles = new Vector3(debugGodObject.transform.eulerAngles.x, (float)newRotation, debugGodObject.transform.eulerAngles.z);
-            }
-            if (!pantoSync.debug)
-            {
-                GameObject debugObject = pantoSync.GetDebugObject(isUpper);
-                debugObject.transform.eulerAngles = new Vector3(debugObject.transform.eulerAngles.x, (float)newRotation, debugObject.transform.eulerAngles.z);
-                debugObject.transform.position = position;
-                if (newGodObjectPosition != null)
-                {
-                    debugGodObject.transform.position = newGodObjectPosition.Value;
-                    debugGodObject.transform.eulerAngles = new Vector3(debugGodObject.transform.eulerAngles.x, (float)newRotation, debugGodObject.transform.eulerAngles.z);
-                }
-            }
             position = newPosition;
             if (newRotation != null) rotation = (float)newRotation;
             godObjectPosition = newGodObjectPosition;
+
+            GameObject debugGodObject = pantoSync.GetDebugGodObject(isUpper);
+
+            if (!pantoSync.debug)
+            {
+                // Update the visible handle (for visualization)
+                GameObject debugObject = pantoSync.GetDebugObject(isUpper);
+                if (debugObject != null)
+                {
+                    if (newRotation != null)
+                        debugObject.transform.eulerAngles = new Vector3(debugObject.transform.eulerAngles.x, (float)newRotation, debugObject.transform.eulerAngles.z);
+                    debugObject.transform.position = position;
+                }
+
+                // Always update the GodObject position, fallback to handle position if null
+                if (debugGodObject != null)
+                {
+                    Vector3 godPos = newGodObjectPosition ?? position;
+                    debugGodObject.transform.position = godPos;
+                    if (newRotation != null)
+                        debugGodObject.transform.eulerAngles = new Vector3(debugGodObject.transform.eulerAngles.x, (float)newRotation, debugGodObject.transform.eulerAngles.z);
+                    // Debug log for verification
+                    // Debug.Log($"[DualPanto] GodObject {(isUpper ? "Me" : "It")} updated to {godPos}");
+                }
+            }
+            else // Debug mode
+            {
+                if (debugGodObject != null)
+                {
+                    debugGodObject.transform.position = newPosition;
+                    if (newRotation != null)
+                        debugGodObject.transform.eulerAngles = new Vector3(debugGodObject.transform.eulerAngles.x, (float)newRotation, debugGodObject.transform.eulerAngles.z);
+                }
+                GameObject debugObject = pantoSync.GetDebugObject(isUpper);
+                if (debugObject != null)
+                {
+                    debugObject.transform.position = newPosition;
+                    if (newRotation != null)
+                        debugObject.transform.eulerAngles = new Vector3(debugObject.transform.eulerAngles.x, (float)newRotation, debugObject.transform.eulerAngles.z);
+                }
+            }
         }
 
         async public Task TraceObjectByPoints(List<GameObject> cornerObjects, float speed)


### PR DESCRIPTION
Got DualPanto failures down to less than 1 in 10 when starting Play-mode (rest generated by Copilot)

This pull request includes multiple changes aimed at improving error handling, code maintainability, and synchronization logic across various scripts in the project. Key updates include adding null checks for critical components, improving obstacle registration logic, and refining debug and synchronization behavior in the `DualPantoSync` system.

### Error Handling Improvements:
* Added null checks for `LowerHandle` and `UpperHandle` in `ItHandle` and `MeHandle` scripts, respectively, with error logs to handle missing components during initialization. (`Assets/ExampleScripts/ItHandle.cs` [[1]](diffhunk://#diff-93bc1ae28ba14fa4038bbf7cd280947127699086fba3196b7d7a9b71eb8896b2R8-R21) `Assets/ExampleScripts/MeHandle.cs` [[2]](diffhunk://#diff-8de05fca5090ad59cca3e81abc79af5cb37919efc4982f08f750d53f52b4e82cL6-R20)

### Obstacle Registration Logic:
* Fixed the logic in `ColliderRegistry.RegisterObstacles` to ensure obstacles are only enabled if they are not already enabled. (`Assets/PantoScripts/ColliderRegistry.cs` [Assets/PantoScripts/ColliderRegistry.csL17-R17](diffhunk://#diff-80b1664e2b96c7357722a3921a329ff6a8a514d41437ddec7a306b66a70fe006L17-R17))
* Adjusted obstacle creation logic in `ActivateObstaclesSphere` to remove a redundant check and ensure proper enabling of obstacles. (`Assets/PantoScripts/ActivateObstaclesSphere.cs` [Assets/PantoScripts/ActivateObstaclesSphere.csL16](diffhunk://#diff-eff01bb38b0b5bd790aa11b4dcc9123414cfdf2dbeecdb6006ec97813067eda9L16))

### Synchronization and Debug Enhancements:
* Updated `DualPantoSync` to use asynchronous logic in `OnPantoStarted` for proper synchronization of handles before marking the system as ready. Added debug logs for better visibility. (`Assets/PantoScripts/DualPantoSync.cs` [Assets/PantoScripts/DualPantoSync.csL209-R226](diffhunk://#diff-1cf85941a942ebc952af68caf30173c961e743012045ae960946b938ac16cc65L209-R226))
* Improved debug and connected state checks in methods like `UpdateHandlePosition` and `CreateObstacle` to prevent unintended behavior when the system is not fully connected. (`Assets/PantoScripts/DualPantoSync.cs` [[1]](diffhunk://#diff-1cf85941a942ebc952af68caf30173c961e743012045ae960946b938ac16cc65R527) [[2]](diffhunk://#diff-1cf85941a942ebc952af68caf30173c961e743012045ae960946b938ac16cc65R643)

### Code Cleanup and Refactoring:
* Removed unused or commented-out code, such as the `async void Start()` method in `RegisterCollider`, to improve code readability. (`Assets/Overcooked/RegisterCollider.cs` [[1]](diffhunk://#diff-e406918fa8b137da64e4d5dbe030b5d0197c92f964a9be1e655b32655cde68a8R7) [[2]](diffhunk://#diff-e406918fa8b137da64e4d5dbe030b5d0197c92f964a9be1e655b32655cde68a8R18)
* Refactored `SetPositions` in `PantoHandle` to streamline debug object updates and ensure consistent behavior between debug and non-debug modes. (`Assets/PantoScripts/PantoHandle.cs` [Assets/PantoScripts/PantoHandle.csR236-L263](diffhunk://#diff-7f167a493a12d5f23c33f870758d009c41744632604b8662a8e400eb51daf029R236-L263))

### Miscellaneous:
* Added `System.Threading.Tasks` import in `DualPantoSync` to support asynchronous operations. (`Assets/PantoScripts/DualPantoSync.cs` [Assets/PantoScripts/DualPantoSync.csR4](diffhunk://#diff-1cf85941a942ebc952af68caf30173c961e743012045ae960946b938ac16cc65R4))