### PR TITLE
Connect battery voltage to UI

### DIFF
--- a/Assets/ExampleScenes/Obstacles.unity
+++ b/Assets/ExampleScenes/Obstacles.unity
@@ -305,7 +305,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 'Battery Voltage:'
+  m_Text: 'Battery:'
 --- !u!222 &194536906
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -388,7 +388,7 @@ GameObject:
   - component: {fileID: 298477318}
   - component: {fileID: 298477317}
   m_Layer: 10
-  m_Name: CurrentBatteryVoltage
+  m_Name: CurrentBatteryPercentage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -683,6 +683,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5991186418955879667, guid: f08d327e9fb42f94d97ba9d1d226d418,
         type: 3}
+      propertyPath: minBatteryVoltage
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5991186418955879667, guid: f08d327e9fb42f94d97ba9d1d226d418,
+        type: 3}
       propertyPath: currentBatteryVoltage
       value: 
       objectReference: {fileID: 298477317}
@@ -690,6 +695,31 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -88.70004
+      objectReference: {fileID: 0}
+    - target: {fileID: 8827900398297005970, guid: f08d327e9fb42f94d97ba9d1d226d418,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 280
+      objectReference: {fileID: 0}
+    - target: {fileID: 8827900398297005970, guid: f08d327e9fb42f94d97ba9d1d226d418,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 43.769997
+      objectReference: {fileID: 0}
+    - target: {fileID: 8827900398297005970, guid: f08d327e9fb42f94d97ba9d1d226d418,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 8827900398297005970, guid: f08d327e9fb42f94d97ba9d1d226d418,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -12.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8827900398297005970, guid: f08d327e9fb42f94d97ba9d1d226d418,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -42
       objectReference: {fileID: 0}
     - target: {fileID: 9078697684515870706, guid: f08d327e9fb42f94d97ba9d1d226d418,
         type: 3}

--- a/Assets/PantoScripts/DualPantoSync.cs
+++ b/Assets/PantoScripts/DualPantoSync.cs
@@ -265,7 +265,11 @@ namespace DualPantoToolkit
             Debug.DrawLine(upperHandlePos + upper * Vector3.back * 0.5f, upperHandlePos + upper * Vector3.forward, Color.black);
             Debug.DrawLine(upperHandlePos + upper * Vector3.left * 0.5f, upperHandlePos + upper * Vector3.right * 0.5f, Color.black);
             batteryVoltage = (float)positions[10];
-            if (showRawValues) uiManager.UpdateValues(positions);
+            if (showRawValues)
+            {
+                uiManager.UpdateValues(positions);
+                uiManager.UpdateBatteryVoltage(batteryVoltage);
+            }
         }
 
         private static ulong OpenPort(string port)

--- a/Assets/Resources/UIManager.cs
+++ b/Assets/Resources/UIManager.cs
@@ -20,7 +20,9 @@ namespace DualPantoToolkit
         public Text currentPhysicsFps;
         public Text currentLowerHandle;
         public Text currentBatteryVoltage;
-        public float batteryWarningThreshold = 7f;
+        public float batteryWarningPercentageThreshold = 20f;
+        public float minBatteryVoltage = 11.2f;   // Voltage considered 0%
+        public float maxBatteryVoltage = 12.6f;   // Voltage considered 100%
         Color defaultBatteryColor;
         DateTime lastHeartbeat;
         void Start()
@@ -87,8 +89,11 @@ namespace DualPantoToolkit
         }
         public void UpdateBatteryVoltage(float voltage)
         {
-            currentBatteryVoltage.text = voltage.ToString("F2");
-            currentBatteryVoltage.color = voltage < batteryWarningThreshold ? Color.red : defaultBatteryColor;
+            // Convert voltage reading to a clamped battery percentage
+            float percentage = Mathf.Clamp01((voltage - minBatteryVoltage) / (maxBatteryVoltage - minBatteryVoltage)) * 100f;
+
+            currentBatteryVoltage.text = percentage.ToString("F0") + " %";
+            currentBatteryVoltage.color = percentage < batteryWarningPercentageThreshold ? Color.red : defaultBatteryColor;
         }
         public void UpdateHeartbeat()
         {

--- a/Assets/Resources/UIManager.cs
+++ b/Assets/Resources/UIManager.cs
@@ -20,10 +20,13 @@ namespace DualPantoToolkit
         public Text currentPhysicsFps;
         public Text currentLowerHandle;
         public Text currentBatteryVoltage;
+        public float batteryWarningThreshold = 7f;
+        Color defaultBatteryColor;
         DateTime lastHeartbeat;
         void Start()
         {
             lastHeartbeat = DateTime.Now;
+            defaultBatteryColor = currentBatteryVoltage.color;
             if (Application.platform == RuntimePlatform.WindowsEditor || Application.platform == RuntimePlatform.WindowsPlayer)
             {
                 portInput.text = DefaultWindowsPort;
@@ -81,6 +84,11 @@ namespace DualPantoToolkit
         public void UpdateIOFps(string newFps)
         {
             currentIOFps.text = newFps;
+        }
+        public void UpdateBatteryVoltage(float voltage)
+        {
+            currentBatteryVoltage.text = voltage.ToString("F2");
+            currentBatteryVoltage.color = voltage < batteryWarningThreshold ? Color.red : defaultBatteryColor;
         }
         public void UpdateHeartbeat()
         {


### PR DESCRIPTION
## Summary
- display battery voltage in the debug UI
- allow warning threshold for low voltage
- show voltage from DualPantoSync

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d428a48d4832ab3968a7ef86ee6cd