### PR TITLE
Fix editor freeze when the device never sends SYNC on connect

### DIFF
--- a/Assets/PantoScripts/DualPantoSync.cs
+++ b/Assets/PantoScripts/DualPantoSync.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -53,6 +54,12 @@ namespace DualPantoToolkit
         public bool debug = false;
         public float debugRotationSpeed = 10.0f;
         public bool showRawValues = true;
+
+        [Header("Connection (hardware mode only)")]
+        [Tooltip("Hard-reset the Panto via the serial DTR/RTS lines before connecting. The firmware only initiates the SYNC handshake right after booting, so without a reset a reconnect (e.g. re-entering Play mode) can wait forever for a SYNC that never comes.")]
+        public bool resetDeviceOnConnect = true;
+        [Tooltip("Seconds to wait for the firmware's SYNC handshake before giving up with an error instead of freezing Unity. 0 = wait forever (legacy behavior).")]
+        public float syncTimeout = 8f;
         protected ulong Handle;
         private static LowerHandle lowerHandle;
         private static UpperHandle upperHandle;
@@ -302,6 +309,10 @@ namespace DualPantoToolkit
             portName = name;
             uiManager.UpdatePort(portName);
             uiManager.ShowPortWindow(false);
+            if (resetDeviceOnConnect && SerialPortReset.TryHardReset(portName))
+            {
+                Debug.Log("[DualPanto] Device reset via DTR/RTS, waiting for it to boot and SYNC");
+            }
             Handle = OpenPort(portName);
             if (Handle == (ulong)0)
             {
@@ -355,11 +366,25 @@ namespace DualPantoToolkit
                 SetTransitionHandler(StaticTransitionHandler);
 
                 SetPort(portName);
-                // keep polling until we receive the first SYNC (which we ACK in the handler and set connected)
-                // only then everyone else can start sending their own stuff
+                // Keep polling until we receive the first SYNC (which we ACK in the handler
+                // and set connected). Only then may everyone else start sending their own
+                // data. The wait must be bounded: the firmware only initiates the handshake
+                // right after booting, so a device that missed the reset would never SYNC,
+                // and an unbounded loop here would freeze the whole editor because this runs
+                // on the main thread and never returns to the UI event loop.
+                float syncWaitStart = Time.realtimeSinceStartup;
                 while (Handle != 0 && !connected)
                 {
                     Poll(Handle);
+                    Thread.Sleep(1); // don't burn a full core while waiting
+                    if (syncTimeout > 0 && Time.realtimeSinceStartup - syncWaitStart > syncTimeout)
+                    {
+                        Debug.LogError($"[DualPanto] No SYNC from the device within {syncTimeout}s. Power-cycle or reset the Panto, then press Play again.");
+                        Close(Handle);
+                        Handle = 0;
+                        uiManager.ShowPortWindow(true);
+                        break;
+                    }
                 }
             }
             else

--- a/Assets/PantoScripts/SerialPortReset.cs
+++ b/Assets/PantoScripts/SerialPortReset.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using UnityEngine;
+
+namespace DualPantoToolkit
+{
+    /// <summary>
+    /// Best-effort hard reset of the Panto through the serial control lines (DTR/RTS),
+    /// used to make the firmware's SYNC handshake deterministic on every connect.
+    ///
+    /// Background: the firmware only initiates the SYNC handshake right after booting.
+    /// Whether the ESP32 reboots when the serial port is (re)opened depends on driver
+    /// side effects, which is why reconnecting (e.g. re-entering Play mode) sometimes
+    /// hangs waiting for a SYNC that never comes. Pulsing the lines explicitly removes
+    /// that dependency on driver behavior.
+    ///
+    /// The pulse follows the standard ESP32 auto-reset sequence (same as esptool and
+    /// the Arduino IDE): assert RTS (EN low) while DTR is deasserted (IO0 high), wait,
+    /// release RTS. Keeping IO0 high during the EN rising edge is what boots the chip
+    /// into the firmware instead of the serial bootloader. On boards without the
+    /// standard auto-reset wiring the pulse is a harmless no-op on the chip.
+    ///
+    /// Implemented via P/Invoke because System.IO.Ports is not available at Unity's
+    /// .NET Standard API compatibility level.
+    /// </summary>
+    public static class SerialPortReset
+    {
+        /// <summary>
+        /// Pulses the reset line of the device behind <paramref name="portName"/>.
+        /// Returns true if the pulse was sent, false if the port could not be opened
+        /// or the platform call failed. Never throws.
+        /// </summary>
+        public static bool TryHardReset(string portName)
+        {
+            try
+            {
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+                return HardResetWindows(portName);
+#else
+                return HardResetPosix(portName);
+#endif
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[DualPanto] Could not reset device on {portName}: {e.Message}");
+                return false;
+            }
+        }
+
+        private const int ResetPulseMs = 100;
+
+#if !UNITY_EDITOR_WIN && !UNITY_STANDALONE_WIN
+        // --- POSIX (Linux / macOS): toggle the modem control lines via ioctl(2) ---
+
+        [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+        private static extern int PosixOpen(string pathname, int flags);
+        [DllImport("libc", EntryPoint = "close")]
+        private static extern int PosixClose(int fd);
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int PosixIoctl(int fd, UIntPtr request, ref int argp);
+
+        private const int TIOCM_DTR = 0x002;
+        private const int TIOCM_RTS = 0x004;
+
+        private static bool HardResetPosix(string portName)
+        {
+            bool isLinux = Application.platform == RuntimePlatform.LinuxEditor
+                || Application.platform == RuntimePlatform.LinuxPlayer;
+
+            // open(2) flags and ioctl(2) request numbers differ between Linux and Darwin
+            int O_RDWR = 2;
+            int O_NOCTTY = isLinux ? 0x100 : 0x20000;
+            int O_NONBLOCK = isLinux ? 0x800 : 0x4;
+            UIntPtr TIOCMBIS = (UIntPtr)(isLinux ? 0x5416u : 0x8004746Cu); // set line bits
+            UIntPtr TIOCMBIC = (UIntPtr)(isLinux ? 0x5417u : 0x8004746Bu); // clear line bits
+
+            int fd = PosixOpen(portName, O_RDWR | O_NOCTTY | O_NONBLOCK);
+            if (fd < 0) return false;
+            try
+            {
+                int dtr = TIOCM_DTR;
+                int rts = TIOCM_RTS;
+                if (PosixIoctl(fd, TIOCMBIC, ref dtr) < 0) return false; // clear DTR: IO0 high, normal boot
+                if (PosixIoctl(fd, TIOCMBIS, ref rts) < 0) return false; // set RTS: EN low, hold chip in reset
+                Thread.Sleep(ResetPulseMs);
+                if (PosixIoctl(fd, TIOCMBIC, ref rts) < 0) return false; // clear RTS: EN high, chip boots
+                return true;
+            }
+            finally
+            {
+                PosixClose(fd);
+            }
+        }
+#else
+        // --- Windows: EscapeCommFunction on a CreateFile handle ---
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateFileW(string fileName, uint access, uint shareMode,
+            IntPtr security, uint disposition, uint flags, IntPtr template);
+        [DllImport("kernel32.dll")]
+        private static extern bool EscapeCommFunction(IntPtr handle, uint func);
+        [DllImport("kernel32.dll")]
+        private static extern bool CloseHandle(IntPtr handle);
+
+        private const uint GENERIC_READ = 0x80000000;
+        private const uint GENERIC_WRITE = 0x40000000;
+        private const uint OPEN_EXISTING = 3;
+        private const uint SETRTS = 3;
+        private const uint CLRRTS = 4;
+        private const uint CLRDTR = 6;
+        private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
+        private static bool HardResetWindows(string portName)
+        {
+            IntPtr handle = CreateFileW(portName.Replace('/', '\\'),
+                GENERIC_READ | GENERIC_WRITE, 0, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (handle == INVALID_HANDLE_VALUE) return false;
+            try
+            {
+                if (!EscapeCommFunction(handle, CLRDTR)) return false; // clear DTR: IO0 high, normal boot
+                if (!EscapeCommFunction(handle, SETRTS)) return false; // set RTS: EN low, hold chip in reset
+                Thread.Sleep(ResetPulseMs);
+                if (!EscapeCommFunction(handle, CLRRTS)) return false; // clear RTS: EN high, chip boots
+                return true;
+            }
+            finally
+            {
+                CloseHandle(handle);
+            }
+        }
+#endif
+    }
+}

--- a/Assets/PantoScripts/SerialPortReset.cs.meta
+++ b/Assets/PantoScripts/SerialPortReset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5ae904e96864d018f2dd1f00bfb37c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ On the back of your dualPanto device is a power switch. Push so that it turns to
 On the back of your dualPanto device is a button next to the USB port. Move the linkages back in the closing position, turn the handles so they point to the right, press the button and wait 3 seconds.
 
 ### Unity freezes upon starting the dualpanto application
-Press the reset button right next to the USB port.
+The toolkit resets the device over its serial control lines before connecting, so the firmware boots fresh and completes the SYNC handshake. If the device still does not answer within the configured timeout, connecting aborts with a Console error instead of freezing Unity. If you see that error, power-cycle the Panto or press the reset button next to the USB port, then press Play again.
 
 ### dualPanto handles not moving inside the game/Message _Revision id not matching. Try resetting the panto._ appears.
 Try to reset the dualPanto device using the button on the back. For this see _How do I reset my dualPanto device._


### PR DESCRIPTION
## Problem

Pressing Play in hardware mode can freeze the whole Unity Editor (100% CPU, unresponsive window, the process has to be killed), typically after a few Play/Stop cycles. This is the issue the troubleshooting section worked around with "press the reset button next to the USB port before playing".

## Cause

The firmware only initiates the SYNC handshake right after booting. Unity is never told a session ended, so whether a reconnect gets a SYNC depends on the serial driver happening to toggle DTR/RTS (and thereby reset the device) when the port is opened. `DualPantoSync` waited for that SYNC in an unbounded loop on the main thread, so when no SYNC arrives the main thread spins forever and the editor never returns to its event loop.

## Fix

1. `SetPort` pulses DTR/RTS to reset the device before opening the port (the standard ESP32 auto-reset sequence used by esptool and the Arduino IDE), so the firmware boots fresh and initiates the handshake. This lives in the new `SerialPortReset` helper and uses P/Invoke because `System.IO.Ports` is not available at Unity's .NET Standard API level. It is a no-op on boards without auto-reset wiring and can be disabled with the `resetDeviceOnConnect` field.
2. The SYNC wait is bounded by a new `syncTimeout` field (default 8 seconds). On timeout it logs a Console error, closes the port and reopens the port selection window instead of freezing, and it sleeps 1 ms per poll instead of busy-waiting. Setting `syncTimeout` to 0 restores the previous unbounded behavior.

A successful connection behaves exactly as before, and emulator mode (`debug = true`) is unaffected.

## Testing

Reproduced the freeze on Linux (Unity 6000.4.6f1, device on /dev/ttyUSB0) by repeatedly entering and exiting Play mode without resetting the device. With the timeout in place the same sequence logs the Console error and the editor stays responsive.
