### PR TITLE
Resolving long response time of SwitchTo() method

### DIFF
--- a/Assets/PantoScripts/PantoHandle.cs
+++ b/Assets/PantoScripts/PantoHandle.cs
@@ -72,7 +72,7 @@ namespace DualPantoToolkit
 
             while (inTransition)
             {
-                if (time > 3000)
+                if (time > 1)
                 {
                     Debug.Log("Abandoning gameobject that couldn't be reached: " + handledGameObject.name);
                     inTransition = false;


### PR DESCRIPTION
With this implementation, we have fixed the issue where the handles had a very long response time when using the `SwitchTo()` method.

We reduced the timeout, and that’s what worked for us. It’s likely that the timeout could be removed entirely, but unfortunately we can no longer test this as we no longer have a DualPanto available.